### PR TITLE
Remove `gh_pr_create_options` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,3 @@ Version to change to.
 
 - required
 - e.g. `1.2.3`
-
-### `gh_pr_create_options`
-
-Additional options for `gh pr create` command.
-
-- optional
-- e.g. `--draft`

--- a/action.yml
+++ b/action.yml
@@ -4,10 +4,6 @@ inputs:
   command:
     description: Shell command for modifying files that contain versions such as package.json, Catgo.toml, etc.
     required: true
-  gh_pr_create_options:
-    description: Additional options for `gh pr create` command.
-    required: false
-    default: ""
   github_token:
     description: GitHub access token.
     required: false
@@ -41,7 +37,7 @@ runs:
         git add .
         git commit --message "Change version to ${{ inputs.version }}"
         git push --set-upstream origin "${branch}"
-        gh pr create --body "${body}" --fill ${{ inputs.gh_pr_create_options }}
+        gh pr create --body "${body}" --fill
       env:
         GITHUB_TOKEN: ${{ inputs.github_token || github.token }}
       shell: bash


### PR DESCRIPTION
We are planning to change the implementation from shell script to deno in order to provide more useful functions in the future. If this happens, we will no longer be able to provide this option, so we will discontinue it now.