### PR TITLE
Add C# project support

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ This action simply creates a pull request and does nothing more. If you want to 
 Currently, the following types of packages are officially supported.
 
 - crate
+- csproj (only `VersionPrefix` attribute supported)
 - gem
 - npm
 - plain (where version is managed by VERSION file)

--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ This action simply creates a pull request and does nothing more. If you want to 
 Currently, the following types of packages are officially supported.
 
 - crate
-- csproj (only `VersionPrefix` attribute supported)
+- csproj (only `Version` attribute supported)
 - gem
 - npm
 - plain (where version is managed by VERSION file)

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -5,6 +5,8 @@ const version = Deno.env.get("BUMP_REQUEST_VERSION")!;
 
 if (checkCratePackage()) {
   changeCrateVersion(version);
+} else if (checkCsprojPackage()) {
+  changeCsprojVersion(version);
 } else if (checkGemPackage()) {
   changeGemVersion(version);
 } else if (checkNpmPackage()) {
@@ -17,6 +19,10 @@ if (checkCratePackage()) {
 
 function checkCratePackage() {
   return fs.existsSync("Cargo.toml");
+}
+
+function checkCsprojPackage() {
+  return fs.expandGlobSync("**/*.csproj").next().value !== undefined;
 }
 
 function checkGemPackage() {
@@ -37,6 +43,15 @@ function changeCrateVersion(version: string) {
     /version = "[^"]+"/,
     `version = "${version}"`,
   );
+}
+
+function changeCsprojVersion(version: string) {
+  replaceContent(
+    fs.expandGlobSync("**/*.rb").next().value.path,
+    /<VersionPrefix>[^<]+<\/VersionPrefix>/,
+    `<VersionPrefix>${version}</VersionPrefix>`,
+  );
+  exec.exec("dotnet", ["restore"]);
 }
 
 function changeGemVersion(version: string) {

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -47,11 +47,10 @@ function changeCrateVersion(version: string) {
 
 function changeCsprojVersion(version: string) {
   replaceContent(
-    fs.expandGlobSync("**/*.rb").next().value.path,
-    /<VersionPrefix>[^<]+<\/VersionPrefix>/,
-    `<VersionPrefix>${version}</VersionPrefix>`,
+    fs.expandGlobSync("**/*.csproj").next().value.path,
+    /<Version>[^<]+<\/Version>/,
+    `<Version>${version}</Version>`,
   );
-  exec.exec("dotnet", ["restore"]);
 }
 
 function changeGemVersion(version: string) {

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -43,7 +43,6 @@ function changeCrateVersion(version: string) {
     /version = "[^"]+"/,
     `version = "${version}"`,
   );
-  exec.exec("dotnet", ["restore"]);
 }
 
 function changeCsprojVersion(version: string) {
@@ -52,6 +51,7 @@ function changeCsprojVersion(version: string) {
     /<Version>[^<]+<\/Version>/,
     `<Version>${version}</Version>`,
   );
+  exec.exec("dotnet", ["restore"]);
 }
 
 function changeGemVersion(version: string) {

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -46,12 +46,13 @@ function changeCrateVersion(version: string) {
 }
 
 function changeCsprojVersion(version: string) {
+  const csprojPath = fs.expandGlobSync("**/*.csproj").next().value.path;
   replaceContent(
-    fs.expandGlobSync("**/*.csproj").next().value.path,
+    csprojPath,
     /<Version>[^<]+<\/Version>/,
     `<Version>${version}</Version>`,
   );
-  exec.exec("dotnet", ["restore"]);
+  exec.exec("dotnet", ["restore", csprojPath]);
 }
 
 function changeGemVersion(version: string) {

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -46,13 +46,11 @@ function changeCrateVersion(version: string) {
 }
 
 function changeCsprojVersion(version: string) {
-  const csprojPath = fs.expandGlobSync("**/*.csproj").next().value.path;
   replaceContent(
-    csprojPath,
+    fs.expandGlobSync("**/*.csproj").next().value.path,
     /<Version>[^<]+<\/Version>/,
     `<Version>${version}</Version>`,
   );
-  exec.exec("dotnet", ["restore", csprojPath]);
 }
 
 function changeGemVersion(version: string) {

--- a/src/changeVersion.ts
+++ b/src/changeVersion.ts
@@ -43,6 +43,7 @@ function changeCrateVersion(version: string) {
     /version = "[^"]+"/,
     `version = "${version}"`,
   );
+  exec.exec("dotnet", ["restore"]);
 }
 
 function changeCsprojVersion(version: string) {


### PR DESCRIPTION
This Pull Request adds support for C# projects (.csproj files).

.csproj files may contain not only the `Version` attribute but also the `VersionPrefix` and `VersionSuffix`. These `Version`, `VersionPrefix`, and `VersionSuffix` tags are interdependent, and when dealing with prerelease versions (e.g., `v0.0.1-beta.1`), all of these attributes must be considered. However, as my understand, `bump-request` action is currently not concerned with prerelease versions. so this Pull Request only handles the `Version` attribute.

ref:
- https://learn.microsoft.com/ja-jp/nuget/reference/msbuild-targets#pack-target
- https://learn.microsoft.com/ja-jp/dotnet/core/tools/dotnet-pack?tabs=netcore2x#options