### PR TITLE
Fix module resolve issue by adding /v135 to some modules

### DIFF
--- a/src/deps.ts
+++ b/src/deps.ts
@@ -1,6 +1,6 @@
-export * as core from "https://esm.sh/@actions/core@1.10.1?dts";
-export * as exec from "https://esm.sh/@actions/exec@1.1.1?dts";
-export * as github from "https://esm.sh/@actions/github@6.0.0?dts";
+export * as core from "https://esm.sh/v135/@actions/core@1.10.1?dts";
+export * as exec from "https://esm.sh/v135/@actions/exec@1.1.1?dts";
+export * as github from "https://esm.sh/v135/@actions/github@6.0.0?dts";
 export * as semver from "https://esm.sh/semver@7.6.2?dts";
 export * as asserts from "https://deno.land/std@0.65.0/testing/asserts.ts";
 export * as fs from "https://deno.land/std@0.224.0/fs/mod.ts";


### PR DESCRIPTION
Failure log example:

```
...
Download https://esm.sh/once@1.4.0/denonext/once.mjs
Download https://esm.sh/wrappy@1.0.2?target=denonext
Download https://esm.sh/wrappy@1.0.2/denonext/wrappy.mjs
error: Module not found "https://esm.sh/node@18.20.7?target=denonext".
    at https://esm.sh/undici@7.3.0?target=denonext:2:8
Error: Process completed with exit code 1.
```

- https://github.com/r7kamura/rubocop_todo_corrector/actions/runs/13510503111/job/37749601863

I haven't fully understood the causal relationship yet, but I suspect that the issue is caused by the same problem reported below. Therefore, I tried applying a similar workaround as suggested there.

- https://github.com/esm-dev/esm.sh/issues/1034

I suspect that the issue is caused by esm.sh recently dropping build support since esm.sh v136.